### PR TITLE
Support CocoaPods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "react-native-key-pair",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "RSA key public key generator for iOS and Android",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "react-native", "rsa"
+    "react-native",
+    "rsa"
   ],
   "author": "Sam Saffron",
+  "homepage": "https://github.com/samsaffron/react-native-key-pair",
   "license": "MIT"
 }

--- a/react-native-key-pair.podspec
+++ b/react-native-key-pair.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/samsaffron/react-native-key-pair.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
React-native 0.60 and up uses CocoaPods to install iOS dependencies, this brings the plugin up to speed with CocoaPods. 