### PR TITLE
FIX: Remove `createJSModules` Override

### DIFF
--- a/android/src/main/java/com/RNKeyPair/RNKeyPairPackage.java
+++ b/android/src/main/java/com/RNKeyPair/RNKeyPairPackage.java
@@ -18,11 +18,6 @@ public class RNKeyPairPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
No longer needed (and its presence blocks building in current Android SDKs).